### PR TITLE
Decouple version metadata from optional environment dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 
 def get_version() -> str:
-    with open(os.path.join("src", "llamafactory", "extras", "env.py"), encoding="utf-8") as f:
+    with open(os.path.join("src", "llamafactory", "version.py"), encoding="utf-8") as f:
         file_content = f.read()
         pattern = r"{}\W*=\W*\"([^\"]+)\"".format("VERSION")
         (version,) = re.findall(pattern, file_content)

--- a/src/llamafactory/cli.py
+++ b/src/llamafactory/cli.py
@@ -41,12 +41,17 @@ def main():
     from .chat.chat_model import run_chat
     from .eval.evaluator import run_eval
     from .extras import logging
-    from .extras.env import VERSION, print_env
+    from .version import VERSION
     from .extras.misc import find_available_port, get_device_count, is_env_enabled, use_ray
     from .train.tuner import export_model, run_exp
     from .webui.interface import run_web_demo, run_web_ui
 
     logger = logging.get_logger(__name__)
+
+    def _print_env() -> None:
+        from .extras.env import print_env
+
+        print_env()
 
     WELCOME = (
         "-" * 58
@@ -63,7 +68,7 @@ def main():
     COMMAND_MAP = {
         "api": run_api,
         "chat": run_chat,
-        "env": print_env,
+        "env": _print_env,
         "eval": run_eval,
         "export": export_model,
         "train": run_exp,

--- a/src/llamafactory/extras/env.py
+++ b/src/llamafactory/extras/env.py
@@ -26,8 +26,7 @@ import transformers
 import trl
 from transformers.utils import is_torch_cuda_available, is_torch_npu_available
 
-
-VERSION = "0.9.4.dev0"
+from ..version import VERSION
 
 
 def print_env() -> None:

--- a/src/llamafactory/version.py
+++ b/src/llamafactory/version.py
@@ -12,20 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""Efficient fine-tuning of large language models.
-
-Level:
-  api, webui > chat, eval, train > data, model > hparams > extras
-
-Disable version checking: DISABLE_VERSION_CHECK=1
-Enable VRAM recording: RECORD_VRAM=1
-Force using torchrun: FORCE_TORCHRUN=1
-Set logging verbosity: LLAMAFACTORY_VERBOSITY=WARN
-Use modelscope: USE_MODELSCOPE_HUB=1
-Use openmind: USE_OPENMIND_HUB=1
-"""
-
-from .version import VERSION
-
-
-__version__ = VERSION
+VERSION = "0.9.4.dev0"


### PR DESCRIPTION
## Summary
- Centralize version string in new `version.py` module and expose it via package init
- Avoid importing heavy `extras.env` during normal CLI use by lazily loading `print_env`
- Reference the shared version constant inside `extras.env`
- Update `setup.py` to read the version from the dedicated module

## Testing
- `pip install --no-cache-dir -e . --no-deps` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai')*
- `docker build -f docker/docker-lite/Dockerfile -t llamafactory-ui-export .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16255eff0832bbf66154929f4722b