### PR TITLE
feat: minimal export-only ui

### DIFF
--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -1,0 +1,20 @@
+FROM python:3.10-slim
+
+# Optional: install git if needed for huggingface or version control
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements-export.txt ./
+RUN pip install --no-cache-dir -r requirements-export.txt
+
+# Copy only UI code and assets
+COPY src ./src
+COPY assets ./assets
+COPY data ./data
+
+ENV PYTHONPATH=/app/src \
+    EXPORT_CONFIG_DIR=/work/configs \
+    EXPORT_DATA_DIR=/work/data
+
+EXPOSE 7860
+CMD ["python", "-c", "from llamafactory.webui.interface import run_web_ui; run_web_ui()"]

--- a/requirements-export.txt
+++ b/requirements-export.txt
@@ -1,0 +1,6 @@
+gradio>=4.38.0,<5.43.0
+pandas>=2.0.0
+numpy<2.0.0
+fastapi
+uvicorn
+datasets<=3.6.0

--- a/src/llamafactory/webui/common.py
+++ b/src/llamafactory/webui/common.py
@@ -15,6 +15,7 @@
 import json
 import os
 import signal
+import shutil
 from collections import defaultdict
 from datetime import datetime
 from typing import Any, Optional, Union
@@ -149,6 +150,24 @@ def load_dataset_info(dataset_dir: str) -> dict[str, dict[str, Any]]:
     except Exception as err:
         logger.warning_rank0(f"Cannot open {os.path.join(dataset_dir, DATA_CONFIG)} due to {str(err)}.")
         return {}
+
+
+def export_datasets(dataset_dir: str, datasets: list[str], dest_dir: str) -> None:
+    r"""Copy selected datasets to destination directory."""
+    os.makedirs(dest_dir, exist_ok=True)
+    dataset_info = load_dataset_info(dataset_dir)
+    for name in datasets:
+        info = dataset_info.get(name)
+        if not info or "file_name" not in info:
+            continue
+        src = os.path.join(dataset_dir, info["file_name"])
+        dst = os.path.join(dest_dir, os.path.basename(info["file_name"]))
+        if os.path.isdir(src):
+            if os.path.exists(dst):
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst)
+        elif os.path.isfile(src):
+            shutil.copy2(src, dst)
 
 
 def load_args(config_path: str) -> Optional[dict[str, Any]]:

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -364,23 +364,23 @@ def create_train_tab(engine: "Engine") -> dict[str, "Component"]:
     )
 
     with gr.Row():
-        cmd_preview_btn = gr.Button()
+        cmd_preview_btn = gr.Button(visible=False)
         arg_save_btn = gr.Button()
-        arg_load_btn = gr.Button()
-        start_btn = gr.Button(variant="primary")
-        stop_btn = gr.Button(variant="stop")
+        arg_load_btn = gr.Button(visible=False)
+        start_btn = gr.Button(variant="primary", visible=False)
+        stop_btn = gr.Button(variant="stop", visible=False)
 
     with gr.Row():
         with gr.Column(scale=3):
             with gr.Row():
                 current_time = gr.Textbox(visible=False, interactive=False)
-                output_dir = gr.Dropdown(allow_custom_value=True)
+                output_dir = gr.Dropdown(allow_custom_value=True, visible=False)
                 config_path = gr.Dropdown(allow_custom_value=True)
 
             with gr.Row():
-                device_count = gr.Textbox(value=str(get_device_count() or 1), interactive=False)
-                ds_stage = gr.Dropdown(choices=["none", "2", "3"], value="none")
-                ds_offload = gr.Checkbox()
+                device_count = gr.Textbox(value=str(get_device_count() or 1), interactive=False, visible=False)
+                ds_stage = gr.Dropdown(choices=["none", "2", "3"], value="none", visible=False)
+                ds_offload = gr.Checkbox(visible=False)
 
             with gr.Row():
                 resume_btn = gr.Checkbox(visible=False, interactive=False)
@@ -390,7 +390,7 @@ def create_train_tab(engine: "Engine") -> dict[str, "Component"]:
                 output_box = gr.Markdown()
 
         with gr.Column(scale=1):
-            loss_viewer = gr.Plot()
+            loss_viewer = gr.Plot(visible=False)
 
     input_elems.update({output_dir, config_path, ds_stage, ds_offload})
     elem_dict.update(
@@ -412,36 +412,17 @@ def create_train_tab(engine: "Engine") -> dict[str, "Component"]:
             loss_viewer=loss_viewer,
         )
     )
-    output_elems = [output_box, progress_bar, loss_viewer, swanlab_link]
 
-    cmd_preview_btn.click(engine.runner.preview_train, input_elems, output_elems, concurrency_limit=None)
-    start_btn.click(engine.runner.run_train, input_elems, output_elems)
-    stop_btn.click(engine.runner.set_abort)
-    resume_btn.change(engine.runner.monitor, outputs=output_elems, concurrency_limit=None)
+    # Hidden buttons above are not connected to any actions
 
     lang = engine.manager.get_elem_by_id("top.lang")
     model_name: gr.Dropdown = engine.manager.get_elem_by_id("top.model_name")
     finetuning_type: gr.Dropdown = engine.manager.get_elem_by_id("top.finetuning_type")
 
-    arg_save_btn.click(engine.runner.save_args, input_elems, output_elems, concurrency_limit=None)
-    arg_load_btn.click(
-        engine.runner.load_args, [lang, config_path], list(input_elems) + [output_box], concurrency_limit=None
-    )
+    arg_save_btn.click(engine.runner.save_args, input_elems, [output_box], concurrency_limit=None)
 
     dataset.focus(list_datasets, [dataset_dir, training_stage], [dataset], queue=False)
     training_stage.change(change_stage, [training_stage], [dataset, packing], queue=False)
-    reward_model.focus(list_checkpoints, [model_name, finetuning_type], [reward_model], queue=False)
-    model_name.change(list_output_dirs, [model_name, finetuning_type, current_time], [output_dir], queue=False)
-    finetuning_type.change(list_output_dirs, [model_name, finetuning_type, current_time], [output_dir], queue=False)
-    output_dir.change(
-        list_output_dirs, [model_name, finetuning_type, current_time], [output_dir], concurrency_limit=None
-    )
-    output_dir.input(
-        engine.runner.check_output_dir,
-        [lang, model_name, finetuning_type, output_dir],
-        list(input_elems) + [output_box],
-        concurrency_limit=None,
-    )
     config_path.change(list_config_paths, [current_time], [config_path], queue=False)
 
     return elem_dict

--- a/src/llamafactory/webui/interface.py
+++ b/src/llamafactory/webui/interface.py
@@ -20,10 +20,7 @@ from ..extras.packages import is_gradio_available
 from .common import save_config
 from .components import (
     create_chat_box,
-    create_eval_tab,
-    create_export_tab,
     create_footer,
-    create_infer_tab,
     create_top,
     create_train_tab,
 )
@@ -49,18 +46,8 @@ def create_ui(demo_mode: bool = False) -> "gr.Blocks":
         engine.manager.add_elems("top", create_top())
         lang: gr.Dropdown = engine.manager.get_elem_by_id("top.lang")
 
-        with gr.Tab("Train"):
+        with gr.Tab("Export"):
             engine.manager.add_elems("train", create_train_tab(engine))
-
-        with gr.Tab("Evaluate & Predict"):
-            engine.manager.add_elems("eval", create_eval_tab(engine))
-
-        with gr.Tab("Chat"):
-            engine.manager.add_elems("infer", create_infer_tab(engine))
-
-        if not demo_mode:
-            with gr.Tab("Export"):
-                engine.manager.add_elems("export", create_export_tab(engine))
 
         engine.manager.add_elems("footer", create_footer())
         demo.load(engine.resume, outputs=engine.manager.get_elem_list(), concurrency_limit=None)

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -2199,19 +2199,19 @@ LOCALES = {
     },
     "arg_save_btn": {
         "en": {
-            "value": "Save arguments",
+            "value": "Export",
         },
         "ru": {
-            "value": "Сохранить аргументы",
+            "value": "Export",
         },
         "zh": {
-            "value": "保存训练参数",
+            "value": "导出",
         },
         "ko": {
-            "value": "Argument 저장",
+            "value": "Export",
         },
         "ja": {
-            "value": "引数を保存",
+            "value": "エクスポート",
         },
     },
     "arg_load_btn": {

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -29,6 +29,7 @@ from .common import (
     DEFAULT_CONFIG_DIR,
     abort_process,
     calculate_pixels,
+    export_datasets,
     gen_cmd,
     get_save_dir,
     load_args,
@@ -39,6 +40,9 @@ from .common import (
 )
 from .control import get_trainer_info
 from .locales import ALERTS, LOCALES
+
+EXPORT_CONFIG_DIR = os.getenv("EXPORT_CONFIG_DIR", "/work/configs")
+EXPORT_DATA_DIR = os.getenv("EXPORT_DATA_DIR", "/work/data")
 
 
 if is_gradio_available():
@@ -469,10 +473,16 @@ class Runner:
 
         lang = data[self.manager.get_elem_by_id("top.lang")]
         config_path = data[self.manager.get_elem_by_id("train.config_path")]
-        os.makedirs(DEFAULT_CONFIG_DIR, exist_ok=True)
-        save_path = os.path.join(DEFAULT_CONFIG_DIR, config_path)
+        os.makedirs(EXPORT_CONFIG_DIR, exist_ok=True)
+        save_path = os.path.join(EXPORT_CONFIG_DIR, config_path)
 
         save_args(save_path, self._build_config_dict(data))
+
+        dataset_dir = data[self.manager.get_elem_by_id("train.dataset_dir")]
+        datasets = data[self.manager.get_elem_by_id("train.dataset")]
+        if dataset_dir and datasets:
+            export_datasets(dataset_dir, datasets, EXPORT_DATA_DIR)
+
         return {output_box: ALERTS["info_config_saved"][lang] + save_path}
 
     def load_args(self, lang: str, config_path: str):


### PR DESCRIPTION
## Summary
- limit web UI to a single Export tab
- copy selected datasets and save hyperparameters to `/work` volumes
- retitle argument save button to "Export"
- add `requirements-export.txt` and lightweight Dockerfile for export-only builds

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68c16a53a428832b8d659d297b366350